### PR TITLE
Create new Tag when element looses focus

### DIFF
--- a/src/tags.js
+++ b/src/tags.js
@@ -262,6 +262,15 @@
                  }
                });
              });
+             
+          /**
+           * complete tag on blur
+           */
+          element.bind('blur', function (evt) {
+            scope.$apply(function () {
+              addTag(ngModel.$viewValue);
+            });
+          });
 
            /**
             * Inspects whatever you typed to see if there were character(s) of


### PR DESCRIPTION
I used the tags directive in a form. When the user entered a new tag and directly clicked on the save/submit button without hitting enter or a separator (,) the entry did not get converted to a _tag_. The changes I propose add a new tag when the `tags` element looses focus
