### PR TITLE
fixed bower.json dependency names to be the common uses

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,10 +3,10 @@
   "version": "0.3.1",
   "main": "dist/angular-tags-0.3.0.js",
   "dependencies": {
-    "angular-ui-bootstrap-bower": "~0.6.0",
+    "angular-bootstrap": "~0.6.0",
     "angular": "1.2.0-rc.1",
     "font-awesome": "~3.2.1",
-    "bootstrap-css": "~3.0.0"
+    "bootstrap": "~3.0.0"
   },
   "devDependencies": {
     "sinonjs": "1.7.1",


### PR DESCRIPTION
Please allow this pull request to go through. Causing a lot of problems at build time with grunt package injection with duplicity of components.
